### PR TITLE
More base2-sizing options

### DIFF
--- a/src/com/gskinner/zoe/views/Main.mxml
+++ b/src/com/gskinner/zoe/views/Main.mxml
@@ -181,7 +181,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 				addEventListener(Event.ENTER_FRAME, tick);
 				
 				imageExportList.dataProvider = new ArrayList([
-					{label:'SpriteSheet (2048 x 2048)', size:2048, type:ExportType.IMAGE_SPRITE_SHEET},
+					{label:'SpriteSheet(2048 x 2048)', size:2048, type:ExportType.IMAGE_SPRITE_SHEET},
+					{label:'SpriteSheet (1024 x 1024)', size:1024, type:ExportType.IMAGE_SPRITE_SHEET },
+					{label:'SpriteSheet (512 x 512)', size:512, type:ExportType.IMAGE_SPRITE_SHEET },
+					{label:'SpriteSheet (256 x 256)', size:256, type:ExportType.IMAGE_SPRITE_SHEET},
 					{label:'Frames', type:ExportType.IMAGE_FRAME}
 				]);
 				


### PR DESCRIPTION
On older models of Iphone that don't support retina display, 2048x2048 is too big and 1024x1024 has to be used instead else it'll downsize it. Also, lower sizes provide more options to conserve memory/file-size.
