### PR TITLE
Update src/com/gskinner/zoe/utils/CaptureSWF.as

### DIFF
--- a/src/com/gskinner/zoe/utils/CaptureSWF.as
+++ b/src/com/gskinner/zoe/utils/CaptureSWF.as
@@ -797,13 +797,8 @@ package com.gskinner.zoe.utils {
 						var ox:Number = 0; 
 						var oy:Number = 0;
 						
-						if (frameData.registrationPoint.x != 0) {
-							ox = frameData.registrationPoint.x-captureRect.x-padding;
-						}
-						
-						if (frameData.registrationPoint.y != 0) {	
-							oy = frameData.registrationPoint.y-captureRect.y-padding;
-						}
+						ox = frameData.registrationPoint.x-captureRect.x-padding;
+						oy = frameData.registrationPoint.y-captureRect.y-padding;
 						
 						//Round the Reg Points
 						ox = Math.round(ox);


### PR DESCRIPTION
Removing conditional could fix the problem that frame offsets does not exports at all when no registrationPoint is present or when is positioned at (0,0);
Please see issue:
https://github.com/CreateJS/Zoe/issues/6
